### PR TITLE
add /tmp to volumes

### DIFF
--- a/bulker/templates/bulker_config.yaml
+++ b/bulker/templates/bulker_config.yaml
@@ -1,5 +1,5 @@
 bulker:
-  volumes: ['$HOME']
+  volumes: ['$HOME', '/tmp']
   envvars: ['DISPLAY']
   registry_url: http://hub.bulker.io/
   shell_path: ${SHELL}


### PR DESCRIPTION
the documentation states that /tmp and $HOME are included by default in the volumes when bulker is used without custom config file: https://bulker.databio.org/en/latest/install/.  This adds the /tmp dir so that the default config matches the documentation.